### PR TITLE
Update to Windows Server 2012 and SQL Server Express 2012

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vagrant-mssql-express
 
-A Windows Server 2008 R2 VM with SQL Server Express 2008 R2 SP2 powered by Vagrant.
+A Windows Server 2012 VM with SQL Server Express 2012 powered by Vagrant.
 
 ## Requirements
 
@@ -18,7 +18,7 @@ A Windows Server 2008 R2 VM with SQL Server Express 2008 R2 SP2 powered by Vagra
 * The box has been created with [packer.io](http://www.packer.io/) using the
   templates made available [here](https://github.com/opentable/packer-images).
 
-More information can be found on the [box page at Vagrant Cloud](https://vagrantcloud.com/opentable/boxes/win-2008r2-standard-amd64-nocm).
+More information can be found on the [box page at Vagrant Cloud](https://atlas.hashicorp.com/opentable/boxes/win-2012r2-standard-amd64-nocm).
 
 ## Usage
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,12 +8,12 @@ ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 if ! File.exists?('./SQLEXPRWT_x64_ENU.exe')
   puts 'SQL Server installer could not be found!'
-  puts "Please run:\n  wget http://download.microsoft.com/download/0/4/B/04BE03CD-EAF3-4797-9D8D-2E08E316C998/SQLEXPRWT_x64_ENU.exe"
+  puts "Please run:\n  wget http://download.microsoft.com/download/8/D/D/8DD7BDBA-CEF7-4D8E-8C16-D9F69527F909/ENU/x64/SQLEXPRWT_x64_ENU.exe"
   exit 1
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "opentable/win-2008r2-standard-amd64-nocm"
+  config.vm.box = "opentable/win-2012r2-standard-amd64-nocm"
   config.vm.network "private_network", ip: "192.168.50.4"
   config.vm.network :forwarded_port, guest: 3389, host: 3389
 

--- a/scripts/configure-sql-port.ps1
+++ b/scripts/configure-sql-port.ps1
@@ -5,14 +5,14 @@ echo "Configuring TCP port"
 
 # http://technet.microsoft.com/en-us/library/dd206997(v=sql.105).aspx
 # Load assemblies
-[reflection.assembly]::LoadWithPartialName("Microsoft.SqlServer.Smo")
-[reflection.assembly]::LoadWithPartialName("Microsoft.SqlServer.SqlWmiManagement")
+Add-Type -Path 'C:\Program Files (x86)\Microsoft SQL Server\110\SDK\Assemblies\Microsoft.SqlServer.Smo.dll'
+Add-Type -Path 'C:\Program Files (x86)\Microsoft SQL Server\110\SDK\Assemblies\Microsoft.SqlServer.SqlWmiManagement.dll'
 
 # http://www.dbi-services.com/index.php/blog/entry/sql-server-2012-configuring-your-tcp-port-via-powershell
 # Set the port
 $smo = 'Microsoft.SqlServer.Management.Smo.'
 $wmi = new-object ($smo + 'Wmi.ManagedComputer')
-$uri = "ManagedComputer[@Name='WIN-2008R2-STD']/ ServerInstance[@Name='SQLEXPRESS']/ServerProtocol[@Name='Tcp']"
+$uri = "ManagedComputer[@Name='" + (get-item env:computername).Value + "']/ ServerInstance[@Name='SQLEXPRESS']/ServerProtocol[@Name='Tcp']"
 $Tcp = $wmi.GetSmoObject($uri)
 $wmi.GetSmoObject($uri + "/IPAddress[@Name='IPAll']").IPAddressProperties[1].Value="1433"
 $Tcp.alter()

--- a/scripts/install-sql-server.cmd
+++ b/scripts/install-sql-server.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-echo Installing SQL Server 2008 Express R2, it will take a while...
+echo Installing SQL Server 2012 Express, it will take a while...
 C:\vagrant\SQLEXPRWT_x64_ENU.exe /Q /Action=install /INDICATEPROGRESS /INSTANCENAME="SQLEXPRESS" /INSTANCEID="SQLExpress" /IAcceptSQLServerLicenseTerms /FEATURES=SQL,Tools /TCPENABLED=1 /SECURITYMODE="SQL" /SAPWD="#SAPassword!"
 echo Done!
 


### PR DESCRIPTION
I wanted to use SQL Server 2012 for the latest [rails sql server adapter](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter) but Windows Server 2008 doesn't support it so I had to update both.  

Feel free to decline this if people are relying on 2008 functionality but I thought some might find it useful.  

I have tested this on a mac using :
Vagrant 1.7.2
Virtualbox 4.3.6
- Updated to SQL Server Express 2012.  Hat tip to [downloadsqlserverexpress.com](http://downloadsqlserverexpress.com/)
- Updated to a [Windows Server 2012](https://atlas.hashicorp.com/opentable/boxes/win-2012r2-standard-amd64-nocm) box
- Slight update to port configuration
  -  Add-Type vs LoadWithPartialName.  Lwpn is deprecated.  It worked if I ran the script while logged in to the machine but failed when it was run via vagrant provision.
  - Use get-item to retrieve computer name.

Thanks for building this in the first place, it was very helpful.
